### PR TITLE
add ability to disable dnssec

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,10 +16,12 @@
 #
 
 class bind::service (
-  $forwarders     = [],
-  $maxrefreshtime = undef,
-  $minrefreshtime = undef,
-  $recursion      = undef,
+  $forwarders        = [],
+  $maxrefreshtime    = undef,
+  $minrefreshtime    = undef,
+  $recursion         = undef,
+  $dnssec_enabled    = yes,
+  $dnssec_validation = yes,
 ) {
   validate_array($forwarders)
 

--- a/manifests/zone_add.pp
+++ b/manifests/zone_add.pp
@@ -37,28 +37,28 @@ define bind::zone_add (
     # Check if this is a reverse zone
     if $name =~ /^(\d+).*arpa$/ {
       bind::ptr_zone { $name:
-        zone         => $name,
-        cidrsize     => $cidr,
-        ttl          => $ttl,
-        refresh      => $refresh,
-        retry        => $retry,
-        expire       => $expire,
-        negresp      => $negresp,
-        nameservers  => $nameservers,
+        zone        => $name,
+        cidrsize    => $cidr,
+        ttl         => $ttl,
+        refresh     => $refresh,
+        retry       => $retry,
+        expire      => $expire,
+        negresp     => $negresp,
+        nameservers => $nameservers,
       }
     }
     else {
       bind::fwd_zone { $name:
-        zone         => $name,
-        ttl          => $ttl,
-        refresh      => $refresh,
-        retry        => $retry,
-        expire       => $expire,
-        negresp      => $negresp,
-        type         => $type,
-        data         => $data,
-        cidr         => $cidr,
-        nameservers  => $nameservers,
+        zone        => $name,
+        ttl         => $ttl,
+        refresh     => $refresh,
+        retry       => $retry,
+        expire      => $expire,
+        negresp     => $negresp,
+        type        => $type,
+        data        => $data,
+        cidr        => $cidr,
+        nameservers => $nameservers,
       }
     }
   }

--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -34,8 +34,8 @@ options {
 <% if @forwarders.count > 0 -%>
   forwarders { <%= @forwarders.join('; ') -%>; };
 <% end -%>
-  dnssec-enable yes;
-  dnssec-validation yes;
+  dnssec-enable <%= @dnssec_enable -%>;
+  dnssec-validation <%= @dnssec_validation -%>;
   dnssec-lookaside auto;
   version "None";
 


### PR DESCRIPTION
You never know when you might come across a signed resource record that for some reason is not tied to a signature in the dns security hierarchy.  This will allow us to reverse the default of yes to security checking, to no, don't check dns security.