### PR TITLE
control where notifies are sent for zone updates.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,6 +22,7 @@ class bind::service (
   $recursion         = undef,
   $dnssec_enable     = yes,
   $dnssec_validation = yes,
+  $zone_notify       = undef,
 ) {
   validate_array($forwarders)
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-bind",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "DNS bind/named config management.",

--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -34,6 +34,9 @@ options {
 <% if @forwarders.count > 0 -%>
   forwarders { <%= @forwarders.join('; ') -%>; };
 <% end -%>
+<% if @zone_notify -%>
+  notify <%= @zone_notify -%>;
+<% end -%>
   dnssec-enable <%= @dnssec_enable -%>;
   dnssec-validation <%= @dnssec_validation -%>;
   dnssec-lookaside auto;
@@ -71,11 +74,16 @@ zone  "<%= zone.chomp(".0/24").split(".").reverse.join(".").concat(".in-addr.arp
       masters { <%= hash['master'].join(';') -%>;};
       <% if hash['slave'] -%>
       allow-transfer { <%= hash['slave'].join(';') -%>;};
+      <% if @zone_notify == 'explicit' -%>
+      also-notify { <%= hash['slave'].join(';') -%>;};
+      <% end -%>
       <% end -%>
     <% else -%>
       file "data/zone_<%= zone.chomp(".0/24").split(".").reverse.join(".").concat(".in-addr.arpa") -%>";
-      notify yes;
       allow-transfer { <%= hash['slave'].join(';') -%>;};
+      <% if @zone_notify == 'explicit' -%>
+      also-notify { <%= hash['slave'].join(';') -%>;};
+      <% end -%>
     <% end -%>
   };
 <% end -%>
@@ -87,11 +95,16 @@ zone  "<%= key %>" {
       masters { <%= hash['master'].join(';') -%>;};
       <% if hash['slave'] -%>
       allow-transfer { <%= hash['slave'].join(';') -%>;};
+      <% if @zone_notify == 'explicit' -%>
+      also-notify { <%= hash['slave'].join(';') -%>;};
+      <% end -%>
       <% end -%>
     <% else -%>
       file "data/zone_<%= key -%>";
-      notify yes;
       allow-transfer { <%= hash['slave'].join(';') -%>;};
+      <% if @zone_notify == 'explicit' -%>
+      also-notify { <%= hash['slave'].join(';') -%>;};
+      <% end -%>
     <% end -%>
   };
 <% end -%>


### PR DESCRIPTION
This change will allow setting notify explicit in the options portion of our named.conf file.

The default behavior for bind is on update all authoritative servers send notifies to every listed NS record server in a zone file.  We would like to not have this happen across data centers or between certain firewall zones.

This option is also available on a per-zone declaration, although I'm having some problems with my variables being populated in the defined type.