### PR TITLE
add support for forwarder only zones

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-bind",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "DNS bind/named config management.",
@@ -12,6 +12,6 @@
     { "operatingsystem":"RedHat", "operatingsystemrelease":[ "6", "7" ] }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": "4.x" }
+    { "name": "puppetlabs/stdlib", "version_requirement": "=> 4.0.0" }
   ]
 }

--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -107,6 +107,9 @@ zone  "<%= key %>" {
       <% else -%>
       allow-transfer {"none";};
       <% end -%>
+    <% elsif hash['type'] == 'forward' -%>
+  forward only;
+  forwarders { <%= hash['forwarders'].join(';') %>;};
     <% else -%>
       file "data/zone_<%= key -%>";
       <% if hash['slave'] -%>


### PR DESCRIPTION
This allows setting a domain type of `forward` with an array of `forwarders`.