### PR TITLE
add support for fake ipam data

### DIFF
--- a/lib/puppet/parser/functions/dns_array.rb
+++ b/lib/puppet/parser/functions/dns_array.rb
@@ -42,7 +42,7 @@ module Puppet::Parser::Functions
         end
       else
         if api_domain =~ /(\d+).*/
-          domain = ".fake.zone"
+          domain = "fake.zone"
         else
           domain = api_domain
         end
@@ -71,6 +71,7 @@ module Puppet::Parser::Functions
           "node21.#{domain}" => "172.16.0.21",
           "node22.#{domain}" => "172.16.0.22",
           "node23.#{domain}" => "172.16.0.23",
+          `hostname`.chomp   => "172.16.0.24",
         }.to_json
       end
     end

--- a/lib/puppet/parser/functions/dns_array.rb
+++ b/lib/puppet/parser/functions/dns_array.rb
@@ -12,6 +12,7 @@ module Puppet::Parser::Functions
         args[1] = ipinfo
         args[2] = asdlgadOuaaeiaoewr234679ds
         args[3] = covermymeds.com 
+        args[4] = true (if set to false, stubs out a fake ipam response)
 
         would return {"host1.example.com" => "192.168.30.22", ...ect}
 
@@ -21,17 +22,56 @@ module Puppet::Parser::Functions
     require "uri"
     require "json"
     begin
-      timeout(40) do
+      api_uri = args[0]
+      api_app = args[1]
+      api_token = args[2]
+      api_domain = args[3]
+      use_ipam = args[4]
+      if use_ipam != false
+        timeout(40) do
 
-      uri = URI.parse("#{args[0]}apiapp=#{args[1]}&apitoken=#{args[2]}&domain=#{args[3]}")
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.ssl_version=:TLSv1_2
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      http.read_timeout = 30
-      request = Net::HTTP::Get.new(uri.request_uri)
-      response = http.request(request)
-      response.body
+          uri = URI.parse("#{api_uri}apiapp=#{api_app}&apitoken=#{api_token}&domain=#{api_domain}")
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = true
+          http.ssl_version=:TLSv1_2
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          http.read_timeout = 30
+          request = Net::HTTP::Get.new(uri.request_uri)
+          response = http.request(request)
+          response.body
+        end
+      else
+        if api_domain =~ /(\d+).*/
+          domain = ".fake.zone"
+        else
+          domain = api_domain
+        end
+        # stub out a fake ipam response
+        {
+          "node1.#{domain}" => "172.16.0.1",
+          "node2.#{domain}" => "172.16.0.2",
+          "node3.#{domain}" => "172.16.0.3",
+          "node4.#{domain}" => "172.16.0.4",
+          "node5.#{domain}" => "172.16.0.5",
+          "node6.#{domain}" => "172.16.0.6",
+          "node7.#{domain}" => "172.16.0.7",
+          "node8.#{domain}" => "172.16.0.8",
+          "node9.#{domain}" => "172.16.0.9",
+          "node10.#{domain}" => "172.16.0.10",
+          "node11.#{domain}" => "172.16.0.11",
+          "node12.#{domain}" => "172.16.0.12",
+          "node13.#{domain}" => "172.16.0.13",
+          "node14.#{domain}" => "172.16.0.14",
+          "node15.#{domain}" => "172.16.0.15",
+          "node16.#{domain}" => "172.16.0.16",
+          "node17.#{domain}" => "172.16.0.17",
+          "node18.#{domain}" => "172.16.0.18",
+          "node19.#{domain}" => "172.16.0.19",
+          "node20.#{domain}" => "172.16.0.20",
+          "node21.#{domain}" => "172.16.0.21",
+          "node22.#{domain}" => "172.16.0.22",
+          "node23.#{domain}" => "172.16.0.23",
+        }.to_json
       end
     end
   end

--- a/manifests/fwd_zone.pp
+++ b/manifests/fwd_zone.pp
@@ -28,7 +28,7 @@ define bind::fwd_zone (
   validate_hash($cname_data)
 
   # Use custom function to query external source for names and IP addresses.
-  $add_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $name))
+  $add_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $name, $::bind::use_ipam))
   if $add_zone == [] {
     $clean_zone = {}
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@
 #
 class bind (
   Hash                  $acls,
+  String                $bind_ip = $::ipaddress,
   Hash                  $domains,
   Hash                  $zones,
   Boolean               $use_ipam = true,

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -23,7 +23,7 @@ define bind::ptr_cidr_zone (
   $cidr_ptr = inline_template('<%= @name.chomp("0/24").split(".").reverse.join(".").concat(".in-addr.arpa") %>')
   $query_zone = chop($zone)
 
-  $cidr_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $query_zone))
+  $cidr_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $query_zone, $::bind::use_ipam))
 
   file{ "/var/named/zone_${cidr_ptr}":
     ensure  => present,

--- a/manifests/ptr_zone.pp
+++ b/manifests/ptr_zone.pp
@@ -39,7 +39,7 @@ define bind::ptr_zone (
   } else {
 
     $ptr_zone = inline_template('<%= @name.chomp(".in-addr.arpa").split(".").reverse.join(".").concat(".0")  %>')
-    $add_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $ptr_zone))
+    $add_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $ptr_zone, $::bind::use_ipam))
 
     file{ "/var/named/zone_${name}":
       ensure  => present,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -28,6 +28,7 @@ class bind::service (
 
   $domains = $::bind::domains
   $acls = $::bind::acls
+  $bind_ip = $::bind::bind_ip
 
   case $::operatingsystemmajrelease {
     '6': {

--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -14,7 +14,7 @@ acl <%= acl -%> {
 <% end %>
 
 options {
-  listen-on port 53 { 127.0.0.1; <%= @ipaddress %>;};
+  listen-on port 53 { 127.0.0.1; <%= @bind_ip %>;};
   directory "/var/named";
   dump-file "/var/named/data/cache_dump.db";
   statistics-file "/var/named/data/named_stats.txt";


### PR DESCRIPTION
add a way to provide the module fake data so that an ipam stack isn't necessary for development work.

This requires https://github.com/covermymeds/puppet-bind/pull/16 which added the use_ipam parameter.
