### PR TITLE
Add support for subdomains

### DIFF
--- a/templates/fwd_zone_file.erb
+++ b/templates/fwd_zone_file.erb
@@ -15,7 +15,7 @@ $TTL <%= @ttl -%>
 <% require 'resolv' -%>
 <% if value =~ Resolv::IPv4::Regex -%>
 <%= key.gsub("\.#{@name}", '') -%>    IN    A   <%= value %>
-<% elsif (key =~ /SUBDOM[1-4]_/) -%>
+<% elsif (key =~ /SUBDOM\d+?_/) -%>
 <% keySUB = key.split('_')[1] -%>
 <%= keySUB.gsub("\.#{@name}", '') -%> IN NS <%= value %>
 <% else -%>

--- a/templates/fwd_zone_file.erb
+++ b/templates/fwd_zone_file.erb
@@ -15,6 +15,9 @@ $TTL <%= @ttl -%>
 <% require 'resolv' -%>
 <% if value =~ Resolv::IPv4::Regex -%>
 <%= key.gsub("\.#{@name}", '') -%>    IN    A   <%= value %>
+<% elsif (key =~ /SUBDOM[1-4]_/) -%>
+<% keySUB = key.split('_')[1] -%>
+<%= keySUB.gsub("\.#{@name}", '') -%> IN NS <%= value %>
 <% else -%>
 <%= key.gsub("\.#{@name}", '') -%>    IN    CNAME   <%= value %>
 <% end -%>


### PR DESCRIPTION
This will allow the addition of subdomains that point to a name server either within your organization or external.

The pattern to use is 'SUBDOM[1-4]_[name of your subdomain]' [authoritative name server]

Hiera example:
'SUBDOM1_foo': ns1.foo.example.com
'SUBDOM2_foo': ns2.foo.example.com