### PR TITLE
Adding keep-response-order

### DIFF
--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -41,6 +41,7 @@ options {
   dnssec-validation <%= @dnssec_validation -%>;
   dnssec-lookaside auto;
   version "None";
+  keep-response-order {any;}
 
   /* Path to ISC DLV key */
   bindkeys-file "/etc/named.iscdlv.key";


### PR DESCRIPTION
This is needed to workaround a bug that was introduced in the latest CentOS version of the bind package.
`keep-response-order` defaults to `any` normally, but this functionality appears to be broken in the latest patch version.
https://bugzilla.redhat.com/show_bug.cgi?id=1720703