### PR TITLE
fixing syntax error and only applying to rhel7

### DIFF
--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -41,7 +41,9 @@ options {
   dnssec-validation <%= @dnssec_validation -%>;
   dnssec-lookaside auto;
   version "None";
-  keep-response-order {any;}
+  <% if @os['release']['major'] == "7" -%>
+  keep-response-order {any;};
+  <% end -%>
 
   /* Path to ISC DLV key */
   bindkeys-file "/etc/named.iscdlv.key";


### PR DESCRIPTION
This will fix the trailing ; syntax error and only apply to rhel7 hosts.

https://bugzilla.redhat.com/show_bug.cgi?id=1720703 specifies only rhel7 and the bind packages on rhel6 do not recognize `keep-response-order` setting anyways.