### PR TITLE
Fixed double-use of file issue

### DIFF
--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -75,10 +75,11 @@ zone "." IN {
    end
 -%>
 <% multizone.each do |zone| -%>
-zone  "<%= zone.chomp(".0/24").split(".").reverse.join(".").concat(".in-addr.arpa") %>" {
+<% subzone_name = zone.chomp(".0/24").split(".").reverse.join(".").concat(".in-addr.arpa") %>
+zone  "<%= subzone_name %>" {
   type <%= hash['type'] -%>;
     <% if hash['type'] == 'slave' -%>
-      file "slaves/zone_<%= key -%>";
+      file "slaves/zone_<%= subzone_name -%>";
       masters { <%= hash['master'].join(';') -%>;};
       <% if hash['slave'] -%>
       allow-transfer { <%= hash['slave'].join(';') -%>;};

--- a/templates/named_conf.erb
+++ b/templates/named_conf.erb
@@ -90,7 +90,7 @@ zone  "<%= subzone_name %>" {
       allow-transfer {"none";};
       <% end -%>
     <% else -%>
-      file "data/zone_<%= zone.chomp(".0/24").split(".").reverse.join(".").concat(".in-addr.arpa") -%>";
+      file "data/zone_<%= subzone_name -%>";
       <% if hash['slave'] -%>
       allow-transfer { <%= hash['slave'].join(';') -%>;};
       <% if @zone_notify == 'explicit' -%>


### PR DESCRIPTION
The configuration file would assign multiple zones to the same zonefile. This apparently was a risky behavior that never had any issues because it programmatically never overlapped.
When CentOS7 changed up to Bind 9.11, a bugfix in 9.9.7 was included which prevents named from starting when named.conf has multiple zones assigned to the same zonefile.

Relevant snippet from: ftp://ftp.isc.org/isc/bind9/9.9.7/RELEASE-NOTES.bind-9.9.7.txt
```
* When files opened for writing by named, such as zone journal files,
  were referenced more than once in named.conf, it could lead to file
  corruption as multiple threads wrote to the same file. This is now
  detected when loading named.conf and reported as an error. [RT
  #37172]
```

This fix ensures that even when CIDRs are split up, they get their own unique zone file.

