### PR TITLE
adding hostname record validation

### DIFF
--- a/manifests/fwd_zone.pp
+++ b/manifests/fwd_zone.pp
@@ -32,7 +32,7 @@ define bind::fwd_zone (
   # We can't trust the data coming from the external source.
   $_invalid_add_zone = $add_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
   $_invalid_add_zone.each |$key, $value| {
-    notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${zone}\' has an invalid value=\'${value}\'": }
+    notify { "bind_validation_failure\: The hostname \'${key}\' in \'${zone}\' is invalid. (ip=\'${value}\')": }
   }
   # Filter out only the valid ones to render to the file
   $valid_add_zone = $add_zone.filter |$key, $value| { $key =~ /^[a-zA-Z0-9.\-]*$/ }

--- a/manifests/fwd_zone.pp
+++ b/manifests/fwd_zone.pp
@@ -32,7 +32,7 @@ define bind::fwd_zone (
   # We can't trust the data coming from the external source.
   $_invalid_add_zone = $add_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
   $_invalid_add_zone.each |$key, $value| {
-    notify { "bind_validation_failure\: The hostname \'${key}\' in \'${zone}\' is invalid. (ip=\'${value}\')": }
+    notify { "bind_validation_failure: The hostname \'${key}\' in \'${zone}\' is invalid. (ip=\'${value}\')": }
   }
   # Filter out only the valid ones to render to the file
   $valid_add_zone = $add_zone.filter |$key, $value| { $key =~ /^[a-zA-Z0-9.\-]*$/ }

--- a/manifests/fwd_zone.pp
+++ b/manifests/fwd_zone.pp
@@ -29,11 +29,19 @@ define bind::fwd_zone (
 
   # Use custom function to query external source for names and IP addresses.
   $add_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $name, $::bind::use_ipam))
-  if $add_zone == [] {
+  # We can't trust the data coming from the external source.
+  $_invalid_add_zone = $add_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
+  $_invalid_add_zone.each |$key, $value| {
+    notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${zone}\' has an invalid value=\'${value}\'": }
+  }
+  # Filter out only the valid ones to render to the file
+  $valid_add_zone = $add_zone.filter |$key, $value| { $key =~ /^[a-zA-Z0-9.\-]*$/ }
+
+  if $valid_add_zone == [] {
     $clean_zone = {}
   }
   else {
-    $clean_zone = $add_zone
+    $clean_zone = $valid_add_zone
   }
 
   # Merge data from custom function and hiera.

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -30,7 +30,7 @@ define bind::ptr_cidr_zone (
   # Refer to RFC-1034
   $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /^[a-zA-Z0-9.\-]*$/ }
   $_invalid_cidr_ptr_zone.each |$key, $value| {
-    warning( "bind_validation_failure\: The hostname for \'${key}\' at \'${value}\' is not valid.")
+    notify { "bind_validation_failure\: The hostname for \'${key}\' at \'${value}\' is not valid.": }
   }
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -29,7 +29,7 @@ define bind::ptr_cidr_zone (
   # Find and notify on invalid ptr zones
   $_invalid_cidr_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
   $_invalid_cidr_ptr_zone.each |$key, $value| {
-    notify { "bind_validation_failure\: The hostname \'${key}\' in \'${zone}\' is invalid (ip=\'${value}\')": }
+    notify { "bind_validation_failure: The hostname \'${key}\' in \'${zone}\' is invalid (ip=\'${value}\')": }
   }
   # Filter out only the valid ones to render to the file
   $valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$key, $value| { $key =~ /^[a-zA-Z0-9.\-]*$/ }

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -28,13 +28,13 @@ define bind::ptr_cidr_zone (
 
   # Select the invalid cidr_ptr_zones and warn about them.
   # Refer to RFC-1034
-  $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /[a-zA-Z0-9.\-]*/ }
+  $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /^[a-zA-Z0-9.\-]*$/ }
   $_invalid_cidr_ptr_zone.each |$key, $value| {
     warning( "bind_validation_failure\: The hostname for \'${key}\' at \'${value}\' is not valid.")
   }
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template
-  $_valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys =~ /[a-zA-Z0-9.\-]*/ }
+  $_valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys =~ /^[a-zA-Z0-9.\-]*$/ }
 
   file{ "/var/named/zone_${cidr_ptr}":
     ensure  => present,

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -29,7 +29,7 @@ define bind::ptr_cidr_zone (
   # Find and notify on invalid ptr zones
   $_invalid_cidr_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
   $_invalid_cidr_ptr_zone.each |$key, $value| {
-    notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${zone}\' has an invalid value=\'${value}\'": }
+    notify { "bind_validation_failure\: The hostname \'${key}\' in \'${zone}\' is invalid (ip=\'${value}\')": }
   }
   # Filter out only the valid ones to render to the file
   $valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$key, $value| { $key =~ /^[a-zA-Z0-9.\-]*$/ }

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -36,7 +36,7 @@ define bind::ptr_cidr_zone (
   #}
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template
-  $valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$items| { $items[0] =~ /^[a-zA-Z0-9.\-]*$/ }
+  #$valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$items| { $items[0] =~ /^[a-zA-Z0-9.\-]*$/ }
   
   exec { "log_errors${cidr_ptr}":
     path    => '/bin',

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -37,7 +37,9 @@ define bind::ptr_cidr_zone (
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template
   $_valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys =~ /^[a-zA-Z0-9.\-]*$/ }
-  notify { "${zone} test ${_valid_cidr_ptr_zone}": }
+  notify { "${zone} test ${_valid_cidr_ptr_zone}":
+    before => File["/var/named/zone_${cidr_ptr}"]
+  }
 
   file{ "/var/named/zone_${cidr_ptr}":
     ensure  => present,

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -37,8 +37,9 @@ define bind::ptr_cidr_zone (
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template
   $_valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys =~ /^[a-zA-Z0-9.\-]*$/ }
-  notify { "${zone} test ${_valid_cidr_ptr_zone}":
-    before => File["/var/named/zone_${cidr_ptr}"]
+  exec { "log_errors${cidr_ptr}":
+    path => '/bin',
+    command => "logger \"puppetbind: test santhony dnsbind ${cidr_ptr}\""
   }
 
   file{ "/var/named/zone_${cidr_ptr}":

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -36,7 +36,7 @@ define bind::ptr_cidr_zone (
   #}
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template
-  #$valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$items| { $items[0] =~ /^[a-zA-Z0-9.\-]*$/ }
+  $valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$items| { $items[0] =~ /^[a-zA-Z0-9.\-]*$/ }
   
   exec { "log_errors${cidr_ptr}":
     path    => '/bin',

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -36,10 +36,12 @@ define bind::ptr_cidr_zone (
   #}
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template
-  $_valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys =~ /^[a-zA-Z0-9.\-]*$/ }
+  $valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$items| { $items[0] =~ /^[a-zA-Z0-9.\-]*$/ }
+  
   exec { "log_errors${cidr_ptr}":
-    path => '/bin',
-    command => "logger \"puppetbind: test santhony dnsbind ${cidr_ptr}\""
+    path    => '/bin',
+    command => "logger \"puppetbind: test santhony dnsbind ${cidr_ptr}\"",
+    before  => File["/var/named/zone_${cidr_ptr}"]
   }
 
   file{ "/var/named/zone_${cidr_ptr}":

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -29,8 +29,10 @@ define bind::ptr_cidr_zone (
   # Select the invalid cidr_ptr_zones and warn about them.
   # Refer to RFC-1034
   $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /^[a-zA-Z0-9.\-]*$/ }
+  notify { "${zone} test ${_invalid_cidr_ptr_zone}": }
+  
   $_invalid_cidr_ptr_zone.each |$key, $value| {
-    notify { "bind_validation_failure\: The hostname for \'${key}\' at \'${value}\' is not valid.": }
+    notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${zone}\' has an invalid value=\'${value}\'": }
   }
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -27,7 +27,7 @@ define bind::ptr_cidr_zone (
   $cidr_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $query_zone, $::bind::use_ipam))
 
   # Find and notify on invalid ptr zones
-  $_invalid_cidr_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
+  $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
   $_invalid_cidr_ptr_zone.each |$key, $value| {
     notify { "bind_validation_failure: The hostname \'${key}\' in \'${zone}\' is invalid (ip=\'${value}\')": }
   }

--- a/manifests/ptr_cidr_zone.pp
+++ b/manifests/ptr_cidr_zone.pp
@@ -28,15 +28,16 @@ define bind::ptr_cidr_zone (
 
   # Select the invalid cidr_ptr_zones and warn about them.
   # Refer to RFC-1034
-  $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /^[a-zA-Z0-9.\-]*$/ }
-  notify { "${zone} test ${_invalid_cidr_ptr_zone}": }
-  
-  $_invalid_cidr_ptr_zone.each |$key, $value| {
-    notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${zone}\' has an invalid value=\'${value}\'": }
-  }
+  #$_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /^[a-zA-Z0-9.\-]*$/ }
+  #notify { "${zone} test ${_invalid_cidr_ptr_zone}": }
+
+  #$_invalid_cidr_ptr_zone.each |$key, $value| {
+  #  notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${zone}\' has an invalid value=\'${value}\'": }
+  #}
 
   # Select only the valid cidr_ptr_zones so that we don't break the zonefile template
   $_valid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys =~ /^[a-zA-Z0-9.\-]*$/ }
+  notify { "${zone} test ${_valid_cidr_ptr_zone}": }
 
   file{ "/var/named/zone_${cidr_ptr}":
     ensure  => present,

--- a/manifests/ptr_zone.pp
+++ b/manifests/ptr_zone.pp
@@ -42,11 +42,14 @@ define bind::ptr_zone (
     $add_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $ptr_zone, $::bind::use_ipam))
 
 
-    $_invalid_cidr_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
-    
-    $_invalid_cidr_ptr_zone.each |$key, $value| {
+    # Find and notify on invalid ptr zones
+    $_invalid_add_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
+    $_invalid_add_ptr_zone.each |$key, $value| {
       notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${ptr_zone}\' has an invalid value=\'${value}\'": }
     }
+
+    # Filter out only the valid ones to render to the file
+    $valid_add_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key =~ /^[a-zA-Z0-9.\-]*$/ }
 
     file{ "/var/named/zone_${name}":
       ensure  => present,

--- a/manifests/ptr_zone.pp
+++ b/manifests/ptr_zone.pp
@@ -45,7 +45,7 @@ define bind::ptr_zone (
     # Find and notify on invalid ptr zones
     $_invalid_add_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
     $_invalid_add_ptr_zone.each |$key, $value| {
-      notify { "bind_validation_failure\: The hostname \'${key}\' in \'${ptr_zone}\' is invalid. (ip=\'${value}\')": }
+      notify { "bind_validation_failure: The hostname \'${key}\' in \'${ptr_zone}\' is invalid. (ip=\'${value}\')": }
     }
 
     # Filter out only the valid ones to render to the file

--- a/manifests/ptr_zone.pp
+++ b/manifests/ptr_zone.pp
@@ -45,7 +45,7 @@ define bind::ptr_zone (
     # Find and notify on invalid ptr zones
     $_invalid_add_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
     $_invalid_add_ptr_zone.each |$key, $value| {
-      notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${ptr_zone}\' has an invalid value=\'${value}\'": }
+      notify { "bind_validation_failure\: The hostname \'${key}\' in \'${ptr_zone}\' is invalid. (ip=\'${value}\')": }
     }
 
     # Filter out only the valid ones to render to the file

--- a/manifests/ptr_zone.pp
+++ b/manifests/ptr_zone.pp
@@ -41,6 +41,13 @@ define bind::ptr_zone (
     $ptr_zone = inline_template('<%= @name.chomp(".in-addr.arpa").split(".").reverse.join(".").concat(".0")  %>')
     $add_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $ptr_zone, $::bind::use_ipam))
 
+
+    $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /^[a-zA-Z0-9.\-]*$/ }
+    
+    $_invalid_cidr_ptr_zone.each |$key, $value| {
+      notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${ptr_zone}\' has an invalid value=\'${value}\'": }
+    }
+
     file{ "/var/named/zone_${name}":
       ensure  => present,
       owner   => root,

--- a/manifests/ptr_zone.pp
+++ b/manifests/ptr_zone.pp
@@ -42,7 +42,7 @@ define bind::ptr_zone (
     $add_ptr_zone = parsejson(dns_array($::bind::data_src, $::bind::data_name, $::bind::data_key, $ptr_zone, $::bind::use_ipam))
 
 
-    $_invalid_cidr_ptr_zone = $cidr_ptr_zone.filter |$keys, $values| { $keys !~ /^[a-zA-Z0-9.\-]*$/ }
+    $_invalid_cidr_ptr_zone = $add_ptr_zone.filter |$key, $value| { $key !~ /^[a-zA-Z0-9.\-]*$/ }
     
     $_invalid_cidr_ptr_zone.each |$key, $value| {
       notify { "bind_validation_failure\: The hostname for \'${key}\' in \'${ptr_zone}\' has an invalid value=\'${value}\'": }

--- a/templates/ptr_cidr_zone_file.erb
+++ b/templates/ptr_cidr_zone_file.erb
@@ -12,7 +12,7 @@ $TTL <%= @ttl -%>
       NS   <%=  n %>.
 <% end %>
 <% oct = @cidr_ptr.split(".")[0] -%>
-<% @_valid_cidr_ptr_zone.each do |key,value| -%>
+<% @valid_cidr_ptr_zone.each do |key,value| -%>
 <% if value.split('.')[2] == oct -%>
 <%= value.split('.')[3] -%>    IN    PTR    <%= key -%>.
 <% end -%>

--- a/templates/ptr_cidr_zone_file.erb
+++ b/templates/ptr_cidr_zone_file.erb
@@ -12,7 +12,7 @@ $TTL <%= @ttl -%>
       NS   <%=  n %>.
 <% end %>
 <% oct = @cidr_ptr.split(".")[0] -%>
-<% @cidr_ptr_zone.each do |key,value| -%>
+<% @_valid_cidr_ptr_zone.each do |key,value| -%>
 <% if value.split('.')[2] == oct -%>
 <%= value.split('.')[3] -%>    IN    PTR    <%= key -%>.
 <% end -%>

--- a/templates/ptr_zone_file.erb
+++ b/templates/ptr_zone_file.erb
@@ -11,6 +11,6 @@ $TTL <%= @ttl -%>
 <% @nameservers.each do |n| -%>
       NS   <%=  n %>.
 <% end %>
-<% @add_ptr_zone.each do |key,value| -%>
+<% @valid_add_ptr_zone.each do |key,value| -%>
 <%= value.split('.')[3] -%>    IN    PTR    <%= key -%>.
 <% end -%>


### PR DESCRIPTION
Add ptr cidr_zone validation code to puppet. This will prevent puppet from managing an invalid config file due to errors in hostname entries in IPAM